### PR TITLE
Remove msl dependencies

### DIFF
--- a/alica_client/CMakeLists.txt
+++ b/alica_client/CMakeLists.txt
@@ -10,7 +10,7 @@ if (${CMAKE_EXTRA_GENERATOR} MATCHES "Eclipse CDT4")
 endif (${CMAKE_EXTRA_GENERATOR} MATCHES "Eclipse CDT4")
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS rqt_gui rqt_gui_cpp alica_ros_proxy msl_actuator_msgs msl_sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS rqt_gui rqt_gui_cpp alica_ros_proxy)
 find_package(Qt5Core REQUIRED)
 get_target_property(Qt5Core_location Qt5::Core LOCATION)
 find_package(Qt5Gui REQUIRED)
@@ -36,7 +36,7 @@ include_directories(${alica_client_INCLUDE_DIRECTORIES} ${catkin_INCLUDE_DIRS})
 catkin_package(
   INCLUDE_DIRS ${alica_client_INCLUDE_DIRECTORIES}
   LIBRARIES ${PROJECT_NAME} AlicaWidget
-  CATKIN_DEPENDS rqt_gui rqt_gui_cpp alica_ros_proxy msl_actuator_msgs msl_sensor_msgs
+  CATKIN_DEPENDS rqt_gui rqt_gui_cpp alica_ros_proxy
 )
 catkin_python_setup()
 
@@ -63,7 +63,6 @@ QT5_WRAP_UI(alica_client_UIS_H ${alica_UIS})
 add_library(AlicaWidget src/alica/AlicaWidget.cpp  ${alica_client_UIS_H})
 
 target_link_libraries(AlicaWidget ${catkin_LIBRARIES} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTNETWORK_LIBRARY} ${QT_QTWIDGETS_LIBRARY})
-add_dependencies(AlicaWidget msl_actuator_msgs_generate_messages_cpp msl_sensor_msgs_generate_messages_cpp)
 
 install(FILES plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/alica_client/include/alica/AlicaWidget.h
+++ b/alica_client/include/alica/AlicaWidget.h
@@ -1,12 +1,4 @@
-/*
- * AlicaWidget.h
- *
- *  Created on: Jul 22, 2015
- *      Author: Stephan Opfer
- */
-
-#ifndef SRC_RQT_ALICA_CLIENT_ALICAWIDGET_H_
-#define SRC_RQT_ALICA_CLIENT_ALICAWIDGET_H_
+#pragma once
 
 #include <alica_ros_proxy/AlicaEngineInfo.h>
 #include <msl_actuator_msgs/KickerStatInfo.h>
@@ -23,12 +15,9 @@ namespace alica
 		AlicaWidget();
 		virtual ~AlicaWidget();
 		void handleAlicaEngineInfo(alica_ros_proxy::AlicaEngineInfoConstPtr aei);
-		void handleKickerStatInfo(msl_actuator_msgs::KickerStatInfoPtr kickStatInfo);
-		void handleSharedWorldInfo(msl_sensor_msgs::SharedWorldInfoPtr sharedWorldInfo);
 		void clearGUI();
 
 		Ui::AlicaWidget uiAlicaWidget;
 		QFrame* qframe;
 	};
 }
-#endif /* SRC_RQT_ALICA_CLIENT_ALICAWIDGET_H_ */

--- a/alica_client/include/alica/AlicaWidget.h
+++ b/alica_client/include/alica/AlicaWidget.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <alica_ros_proxy/AlicaEngineInfo.h>
-#include <msl_actuator_msgs/KickerStatInfo.h>
-#include <msl_sensor_msgs/SharedWorldInfo.h>
 #include <ui_AlicaWidget.h>
 #include <QtGui>
 namespace alica

--- a/alica_client/package.xml
+++ b/alica_client/package.xml
@@ -13,14 +13,10 @@
   <build_depend>rqt_gui</build_depend>
   <build_depend>alica_ros_proxy</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
-  <build_depend>msl_actuator_msgs</build_depend>
-  <build_depend>msl_sensor_msgs</build_depend>
   
-  <run_depend>msl_actuator_msgs</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>alica_ros_proxy</run_depend>
   <run_depend>rqt_gui_cpp</run_depend>
-  <run_depend>msl_sensor_msgs</run_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/alica_client/src/alica/AlicaWidget.cpp
+++ b/alica_client/src/alica/AlicaWidget.cpp
@@ -1,10 +1,3 @@
-/*
- * AlicaWidget.cpp
- *
- *  Created on: Jul 22, 2015
- *      Author: Stephan Opfer
- */
-
 #include "alica/AlicaWidget.h"
 #include <sstream>
 
@@ -40,39 +33,6 @@ namespace alica
 		ss << ")";
 
 		uiAlicaWidget.stateVal->setText(QString(ss.str().c_str()));
-	}
-
-	void AlicaWidget::handleKickerStatInfo(msl_actuator_msgs::KickerStatInfoPtr kickStatInfo)
-	{
-		uiAlicaWidget.kickVoltVal->setText(QString::number(kickStatInfo->capVoltage));
-	}
-
-	void AlicaWidget::handleSharedWorldInfo(msl_sensor_msgs::SharedWorldInfoPtr sharedWorldInfo)
-	{
-		if (sharedWorldInfo->ballPossessionStatus == msl_sensor_msgs::SharedWorldInfo::HAVE_BALL)
-		{
-			uiAlicaWidget.ballPossStateVal->setText(QString("HaveBall"));
-		}
-		else if (sharedWorldInfo->ballPossessionStatus == msl_sensor_msgs::SharedWorldInfo::NO_BALL_SEEN)
-		{
-			uiAlicaWidget.ballPossStateVal->setText(QString("NoBallSeen"));
-		}
-		else if (sharedWorldInfo->ballPossessionStatus == msl_sensor_msgs::SharedWorldInfo::ASIDE_OF_KICKER)
-		{
-			uiAlicaWidget.ballPossStateVal->setText(QString("ASideOfKicker"));
-		}
-		else if (sharedWorldInfo->ballPossessionStatus == msl_sensor_msgs::SharedWorldInfo::NOT_IN_KICKER_DISTANCE)
-		{
-			uiAlicaWidget.ballPossStateVal->setText(QString("NotInKickerDistance"));
-		}
-		else if (sharedWorldInfo->ballPossessionStatus == msl_sensor_msgs::SharedWorldInfo::LIGHT_BARRIER_UNBLOCKED)
-		{
-			uiAlicaWidget.ballPossStateVal->setText(QString("LightBarrierUnblocked"));
-		}
-		else
-		{
-			uiAlicaWidget.ballPossStateVal->setText(QString("Unknown"));
-		}
 	}
 
 	void AlicaWidget::clearGUI()

--- a/alica_client/src/alica/AlicaWidget.ui
+++ b/alica_client/src/alica/AlicaWidget.ui
@@ -50,7 +50,16 @@
    <property name="sizeConstraint">
     <enum>QLayout::SetMinimumSize</enum>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -147,20 +156,6 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QLabel" name="kickVoltLbl">
-       <property name="text">
-        <string>KiVolt:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="ballPossStateLbl">
-       <property name="text">
-        <string>BallPoss:</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>
@@ -249,20 +244,6 @@
        <property name="lineWidth">
         <number>0</number>
        </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="kickVoltVal">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="ballPossStateVal">
        <property name="text">
         <string/>
        </property>

--- a/pm_control/include/pm_widget/ControlledRobot.h
+++ b/pm_control/include/pm_widget/ControlledRobot.h
@@ -1,12 +1,4 @@
-/*
- * ControlledRobot.h
- *
- *  Created on: Feb 27, 2015
- *      Author: Stephan Opfer
- */
-
-#ifndef SUPPLEMENTARY_PM_CONTROL_SRC_PM_WIDGET_CONTROLLEDROBOT_H_
-#define SUPPLEMENTARY_PM_CONTROL_SRC_PM_WIDGET_CONTROLLEDROBOT_H_
+#pragma once
 
 #include <process_manager/RobotMetaData.h>
 #include <process_manager/ProcessStats.h>
@@ -38,16 +30,16 @@ namespace pm_widget
 		Q_OBJECT
 
 	public:
-		ControlledRobot(string robotName, int robotId, int parentPMid); /*<for robot_control*/
+		ControlledRobot(std::string robotName, int robotId, int parentPMid); /*<for robot_control*/
 		virtual ~ControlledRobot();
 
-		void handleProcessStat(chrono::system_clock::time_point timeMsgReceived,process_manager::ProcessStat ps, int parentPMid);
-		void sendProcessCommand(vector<int> execIds, vector<int> paramSets, int cmd);
-		void updateGUI(chrono::system_clock::time_point now);
+		void handleProcessStat(std::chrono::system_clock::time_point timeMsgReceived,process_manager::ProcessStat ps, int parentPMid);
+		void sendProcessCommand(std::vector<int> execIds, std::vector<int> paramSets, int cmd);
+		void updateGUI(std::chrono::system_clock::time_point now);
 		void addExec(QWidget* exec);
 		void removeExec(QWidget* exec);
 
-		chrono::system_clock::time_point timeLastMsgReceived; /* < Time point, when the last message have been received */
+		std::chrono::system_clock::time_point timeLastMsgReceived; /* < Time point, when the last message have been received */
 		QFrame* robotProcessesQFrame; /**< The widget, used to initialise the RobotProcessesWidget */
 		//ControlledProcessManager* parentProcessManager;
 
@@ -55,15 +47,13 @@ namespace pm_widget
 		void updateBundles(QString text);
 
 	private:
-		chrono::duration<double> msgTimeOut;
+		std::chrono::duration<double> msgTimeOut;
 		bool inRobotControl;
-		string selectedBundle;
+		std::string selectedBundle;
 		Ui::RobotProcessesWidget* _robotProcessesWidget;
-		map<int, ControlledExecutable*> controlledExecMap;
+		std::map<int, ControlledExecutable*> controlledExecMap;
 		ros::Publisher processCommandPub;
 		int parentPMid;
 	};
 
 } /* namespace pm_widget */
-
-#endif /* SUPPLEMENTARY_PM_CONTROL_SRC_PM_WIDGET_CONTROLLEDROBOT_H_ */

--- a/robot_control/include/robot_control/Robot.h
+++ b/robot_control/include/robot_control/Robot.h
@@ -1,12 +1,4 @@
-/*
- * ControlledRobot.h
- *
- *  Created on: Feb 27, 2015
- *      Author: Stephan Opfer
- */
-
-#ifndef SUPPLEMENTARY_RQT_ROBOT_CONTROL_SRC_RQT_ROBOT_CONTROL_CONTROLLEDROBOT_H_
-#define SUPPLEMENTARY_RQT_ROBOT_CONTROL_SRC_RQT_ROBOT_CONTROL_CONTROLLEDROBOT_H_
+#pragma once
 
 #include <chrono>
 #include <process_manager/RobotMetaData.h>
@@ -48,20 +40,18 @@ namespace robot_control
 		Q_OBJECT
 
 	public:
-		Robot(string robotName, int robotId, RobotsControl* parentRobotsControl);
+		Robot(std::string robotName, int robotId, RobotsControl* parentRobotsControl);
 
 		virtual ~Robot();
 
 		// Message processing
-		chrono::time_point<chrono::system_clock> timeLastMsgReceived; /**< the last time a message was received for this robot */
-		void handleAlicaInfo(pair<chrono::system_clock::time_point, alica_ros_proxy::AlicaEngineInfoConstPtr> timeAEIpair);
-		void handleKickerStatInfo(pair<chrono::system_clock::time_point, msl_actuator_msgs::KickerStatInfoPtr> timeKSIpair);
-		void handleSharedWorldInfo(pair<chrono::system_clock::time_point, msl_sensor_msgs::SharedWorldInfoPtr> timeSWIpair);
-		void handleProcessStat(chrono::system_clock::time_point timeMsgReceived, process_manager::ProcessStat ps, int parentPMid);
+		std::chrono::time_point<std::chrono::system_clock> timeLastMsgReceived; /**< the last time a message was received for this robot */
+		void handleAlicaInfo(std::pair<std::chrono::system_clock::time_point, alica_ros_proxy::AlicaEngineInfoConstPtr> timeAEIpair);
+		void handleProcessStat(std::chrono::system_clock::time_point timeMsgReceived, process_manager::ProcessStat ps, int parentPMid);
 
 		// GUI Methods and Members
 		RobotsControl* parentRobotsControl;
-		void updateGUI(chrono::system_clock::time_point now);
+		void updateGUI(std::chrono::system_clock::time_point now);
 		void toggle();
 		void show();
 		void hide();
@@ -91,4 +81,3 @@ namespace robot_control
 
 } /* namespace robot_control */
 
-#endif /* SUPPLEMENTARY_RQT_ROBOT_CONTROL_SRC_RQT_ROBOT_CONTROL_CONTROLLEDROBOT_H_ */

--- a/robot_control/include/robot_control/RobotsControl.h
+++ b/robot_control/include/robot_control/RobotsControl.h
@@ -56,8 +56,6 @@ namespace robot_control
 	private:
 		ros::Subscriber processStateSub;
 		ros::Subscriber alicaInfoSub;
-		ros::Subscriber kickerStatInfoSub;
-		ros::Subscriber sharedWorldInfoSub;
 
 		supplementary::SystemConfig* sc;
 
@@ -66,15 +64,9 @@ namespace robot_control
 		std::mutex processStatsMsgQueueMutex;
 		std::queue<std::pair<std::chrono::system_clock::time_point, alica_ros_proxy::AlicaEngineInfoConstPtr>> alicaInfoMsgQueue;
 		std::mutex alicaInfoMsgQueueMutex;
-		std::queue<std::pair<std::chrono::system_clock::time_point, msl_actuator_msgs::KickerStatInfoPtr>> kickerStatInfoMsgQueue;
-		std::mutex kickerStatInfoMsgQueueMutex;
-		std::queue<std::pair<std::chrono::system_clock::time_point, msl_sensor_msgs::SharedWorldInfoPtr>> sharedWorldInfoMsgQueue;
-		std::mutex sharedWorldInfoMsgQueueMutex;
 
 		void receiveProcessStats(process_manager::ProcessStatsConstPtr processStats);
 		void receiveAlicaInfo(alica_ros_proxy::AlicaEngineInfoConstPtr alicaInfo);
-		void receiveKickerStatInfo(msl_actuator_msgs::KickerStatInfoPtr kickerStatInfo);
-		void receiveSharedWorldInfo(msl_sensor_msgs::SharedWorldInfoPtr sharedWorldInfo);
 		void processMessages();
 		void checkAndInit(int robotId);
 

--- a/robot_control/include/robot_control/RobotsControl.h
+++ b/robot_control/include/robot_control/RobotsControl.h
@@ -1,5 +1,4 @@
-#ifndef robot_control__PMControl_H
-#define robot_control__PMControl_H
+#pragma once
 
 #include <rqt_gui_cpp/plugin.h>
 
@@ -9,8 +8,6 @@
 
 #include <process_manager/ProcessStats.h>
 #include <alica_ros_proxy/AlicaEngineInfo.h>
-#include <msl_actuator_msgs/KickerStatInfo.h>
-#include <msl_sensor_msgs/SharedWorldInfo.h>
 
 #include <ui_RobotsControl.h>
 #include <QtGui>
@@ -21,8 +18,6 @@
 #include <mutex>
 #include <utility>
 #include <chrono>
-
-using namespace std;
 
 namespace supplementary
 {
@@ -49,12 +44,12 @@ namespace robot_control
 		void addRobot();
 		void removeRobot();
 
-		static chrono::duration<double> msgTimeOut;
+		static std::chrono::duration<double> msgTimeOut;
 
 		Ui::RobotControlWidget robotControlWidget_;
 		QWidget* widget_;
 
-		map<string, vector<pair<int, int>>> bundlesMap;
+		std::map<std::string, std::vector<std::pair<int, int>>> bundlesMap;
 		supplementary::RobotExecutableRegistry* pmRegistry;
 		ros::NodeHandle* rosNode;
 
@@ -66,15 +61,15 @@ namespace robot_control
 
 		supplementary::SystemConfig* sc;
 
-		map<int, Robot*> controlledRobotsMap;
-		queue<pair<chrono::system_clock::time_point, process_manager::ProcessStatsConstPtr>> processStatMsgQueue;
-		mutex processStatsMsgQueueMutex;
-		queue<pair<chrono::system_clock::time_point, alica_ros_proxy::AlicaEngineInfoConstPtr>> alicaInfoMsgQueue;
-		mutex alicaInfoMsgQueueMutex;
-		queue<pair<chrono::system_clock::time_point, msl_actuator_msgs::KickerStatInfoPtr>> kickerStatInfoMsgQueue;
-		mutex kickerStatInfoMsgQueueMutex;
-		queue<pair<chrono::system_clock::time_point, msl_sensor_msgs::SharedWorldInfoPtr>> sharedWorldInfoMsgQueue;
-		mutex sharedWorldInfoMsgQueueMutex;
+		std::map<int, Robot*> controlledRobotsMap;
+		std::queue<std::pair<std::chrono::system_clock::time_point, process_manager::ProcessStatsConstPtr>> processStatMsgQueue;
+		std::mutex processStatsMsgQueueMutex;
+		std::queue<std::pair<std::chrono::system_clock::time_point, alica_ros_proxy::AlicaEngineInfoConstPtr>> alicaInfoMsgQueue;
+		std::mutex alicaInfoMsgQueueMutex;
+		std::queue<std::pair<std::chrono::system_clock::time_point, msl_actuator_msgs::KickerStatInfoPtr>> kickerStatInfoMsgQueue;
+		std::mutex kickerStatInfoMsgQueueMutex;
+		std::queue<std::pair<std::chrono::system_clock::time_point, msl_sensor_msgs::SharedWorldInfoPtr>> sharedWorldInfoMsgQueue;
+		std::mutex sharedWorldInfoMsgQueueMutex;
 
 		void receiveProcessStats(process_manager::ProcessStatsConstPtr processStats);
 		void receiveAlicaInfo(alica_ros_proxy::AlicaEngineInfoConstPtr alicaInfo);
@@ -92,5 +87,3 @@ namespace robot_control
 	};
 
 }
-
-#endif // rqt_msl_refbox__RefBox_H

--- a/robot_control/src/robot_control/Robot.cpp
+++ b/robot_control/src/robot_control/Robot.cpp
@@ -117,7 +117,7 @@ namespace robot_control
 
 	}
 
-	void Robot::updateGUI(chrono::system_clock::time_point now)
+	void Robot::updateGUI(std::chrono::system_clock::time_point now)
 	{
 		if ((now - this->timeLastMsgReceived) > std::chrono::milliseconds(1000))
 		{
@@ -167,25 +167,13 @@ namespace robot_control
 		QFrame::hide();
 	}
 
-	void Robot::handleAlicaInfo(pair<chrono::system_clock::time_point, alica_ros_proxy::AlicaEngineInfoConstPtr> timeAEIpair)
+	void Robot::handleAlicaInfo(std::pair<std::chrono::system_clock::time_point, alica_ros_proxy::AlicaEngineInfoConstPtr> timeAEIpair)
 	{
 		this->timeLastMsgReceived = timeAEIpair.first;
 		this->alicaWidget->handleAlicaEngineInfo(timeAEIpair.second);
 	}
 
-	void Robot::handleKickerStatInfo(pair<chrono::system_clock::time_point, msl_actuator_msgs::KickerStatInfoPtr> timeKSIpair)
-	{
-		this->timeLastMsgReceived = timeKSIpair.first;
-		this->alicaWidget->handleKickerStatInfo(timeKSIpair.second);
-	}
-
-	void Robot::handleSharedWorldInfo(pair<chrono::system_clock::time_point, msl_sensor_msgs::SharedWorldInfoPtr> timeSWIpair)
-	{
-		this->timeLastMsgReceived = timeSWIpair.first;
-		this->alicaWidget->handleSharedWorldInfo(timeSWIpair.second);
-	}
-
-	void Robot::handleProcessStat(chrono::system_clock::time_point timeMsgReceived, process_manager::ProcessStat ps, int parentPMid)
+	void Robot::handleProcessStat(std::chrono::system_clock::time_point timeMsgReceived, process_manager::ProcessStat ps, int parentPMid)
 	{
 		this->timeLastMsgReceived = timeMsgReceived;
 		this->controlledRobotWidget->handleProcessStat(timeMsgReceived, ps, parentPMid);

--- a/robot_control/src/robot_control/RobotsControl.cpp
+++ b/robot_control/src/robot_control/RobotsControl.cpp
@@ -96,10 +96,6 @@ namespace robot_control
 												(RobotsControl*)this);
 		alicaInfoSub = rosNode->subscribe("/AlicaEngine/AlicaEngineInfo", 10, &RobotsControl::receiveAlicaInfo,
 											(RobotsControl*)this);
-		kickerStatInfoSub = rosNode->subscribe("/KickerStatInfo", 10, &RobotsControl::receiveKickerStatInfo,
-												(RobotsControl*)this);
-		sharedWorldInfoSub = rosNode->subscribe("/WorldModel/SharedWorldInfo", 10,
-												&RobotsControl::receiveSharedWorldInfo, (RobotsControl*)this);
 
 		// Initialise the GUI refresh timer
 		this->guiUpdateTimer = new QTimer();
@@ -245,8 +241,6 @@ namespace robot_control
 	{
 		this->processStateSub.shutdown();
 		this->alicaInfoSub.shutdown();
-		this->kickerStatInfoSub.shutdown();
-		this->sharedWorldInfoSub.shutdown();
 	}
 
 	void RobotsControl::saveSettings(qt_gui_cpp::Settings& plugin_settings,

--- a/robot_control/src/robot_control/RobotsControl.cpp
+++ b/robot_control/src/robot_control/RobotsControl.cpp
@@ -181,18 +181,6 @@ namespace robot_control
 		this->alicaInfoMsgQueue.emplace(chrono::system_clock::now(), alicaInfo);
 	}
 
-	void RobotsControl::receiveKickerStatInfo(msl_actuator_msgs::KickerStatInfoPtr kickerStatInfo)
-	{
-		lock_guard<mutex> lck(kickerStatInfoMsgQueueMutex);
-		this->kickerStatInfoMsgQueue.emplace(chrono::system_clock::now(), kickerStatInfo);
-	}
-
-	void RobotsControl::receiveSharedWorldInfo(msl_sensor_msgs::SharedWorldInfoPtr sharedWorldInfo)
-	{
-		lock_guard<mutex> lck(sharedWorldInfoMsgQueueMutex);
-		this->sharedWorldInfoMsgQueue.emplace(chrono::system_clock::now(), sharedWorldInfo);
-	}
-
 	/**
 	 * Processes all queued messages from the processStatMsgsQueue and the alicaInfoMsgQueue.
 	 */
@@ -224,32 +212,6 @@ namespace robot_control
 				alicaInfoMsgQueue.pop();
 
 				this->controlledRobotsMap[timeAlicaInfoPair.second->senderID]->handleAlicaInfo(timeAlicaInfoPair);
-			}
-		}
-
-		{
-			lock_guard<mutex> lck(kickerStatInfoMsgQueueMutex);
-			while (!this->kickerStatInfoMsgQueue.empty())
-			{
-				// unqueue the ROS kicker stat info message
-				auto timeKickerStatInfoPair = kickerStatInfoMsgQueue.front();
-				kickerStatInfoMsgQueue.pop();
-
-				this->controlledRobotsMap[timeKickerStatInfoPair.second->senderID]->handleKickerStatInfo(
-						timeKickerStatInfoPair);
-			}
-		}
-
-		{
-			lock_guard<mutex> lck(sharedWorldInfoMsgQueueMutex);
-			while (!this->sharedWorldInfoMsgQueue.empty())
-			{
-				// unqueue the ROS shared world info message
-				auto timeSharedWorldInfoPair = sharedWorldInfoMsgQueue.front();
-				sharedWorldInfoMsgQueue.pop();
-
-				this->controlledRobotsMap[timeSharedWorldInfoPair.second->senderID]->handleSharedWorldInfo(
-						timeSharedWorldInfoPair);
 			}
 		}
 


### PR DESCRIPTION
Removed dependencies to msl_msgs, msl_actuator_msgs, msl_sensor_msgs from **robot_control**, in order to make supplementary independent from MSL-Stuff again. You should use the GUI **msl_control** in combination with **robot_control** now. msl_control is **located in cnc-msl (msl_control-Branch)**. A pull-request will be issued there, too. 

**If you accept this pull-request, you are forced to accept the pull-request for cnc-msl (msl_control into master), too.**

